### PR TITLE
Custom adapter class to specify additional config for main extension classes

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -108,6 +108,43 @@ public class WithSelectorsPlaywrightTest {
 }
 ----
 
+=== Custom Playwright configuration
+
+Use `@WithPlaywright(playwrightAdapter = ...)` when you need to adapt low-level Playwright options globally for a test class, where the default options provided by the `@WithPlaywright` annotation are not sufficient. This allows you to customize the Playwright configuration at various stages of the browser and context creation process.
+
+A `PlaywrightAdapter` can customize:
+
+- `Playwright.CreateOptions` via `adaptCreateOptions`
+- `BrowserType.LaunchOptions` via `adaptLaunchOptions`
+- `Browser.NewContextOptions` via `adaptNewContextOptions`
+
+The adapter class must implement `io.quarkiverse.playwright.PlaywrightAdapter` and have a no-argument constructor. Each of the methods has a default no-op implementation, so you can choose to override only the methods relevant to your use case. For example, the following adapter sets a custom viewport size for all contexts created in the test class:
+
+[source, java]
+----
+@QuarkusTest
+@WithPlaywright(playwrightAdapter = WithAdapterPlaywrightTest.CustomAdapter.class)
+public class WithAdapterPlaywrightTest {
+
+    public static class CustomAdapter implements PlaywrightAdapter {
+        @Override
+        public Browser.NewContextOptions adaptNewContextOptions(Browser.NewContextOptions newContextOptions) {
+            return newContextOptions.setViewportSize(100, 200);
+        }
+    }
+
+    @InjectPlaywright
+    BrowserContext context;
+
+    @Test
+    public void testViewport() {
+        final Page page = context.newPage();
+        Assertions.assertEquals(100, page.viewportSize().width);
+        Assertions.assertEquals(200, page.viewportSize().height);
+    }
+}
+----
+
 == Runtime Usage
 
 Leverage Playwright for screen scraping or other browser tasks in your runtime application, including support for GraalVM native compilation.
@@ -416,6 +453,11 @@ public @interface WithPlaywright {
      * Configuration for creation of the {@link com.microsoft.playwright.BrowserContext BrowserContext}
      */
     BrowserContextConfig browserContext() default @BrowserContextConfig;
+
+    /**
+     * Specifies a custom {@link PlaywrightAdapter} implementation to adapt Playwright options.
+     */
+    Class<? extends PlaywrightAdapter> playwrightAdapter() default QuarkusPlaywrightManager.NoOpAdapter.class;
 }
 ----
 

--- a/integration-tests/src/test/java/org/acme/WithAdapterPlaywrightTest.java
+++ b/integration-tests/src/test/java/org/acme/WithAdapterPlaywrightTest.java
@@ -1,0 +1,35 @@
+package org.acme;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.playwright.*;
+
+import io.quarkiverse.playwright.InjectPlaywright;
+import io.quarkiverse.playwright.WithPlaywright;
+import io.quarkus.test.junit.QuarkusTest;
+
+@QuarkusTest
+@WithPlaywright(playwrightAdapter = WithAdapterPlaywrightTest.CustomAdapter.class)
+public class WithAdapterPlaywrightTest {
+
+    public static class CustomAdapter implements io.quarkiverse.playwright.PlaywrightAdapter {
+
+        @Override
+        public Browser.NewContextOptions adaptNewContextOptions(Browser.NewContextOptions newContextOptions) {
+            newContextOptions.setViewportSize(100, 200);
+            return newContextOptions;
+        }
+    }
+
+    @InjectPlaywright
+    BrowserContext context;
+
+    @Test
+    public void testIndex() {
+        final Page page = context.newPage();
+
+        Assertions.assertEquals(100, page.viewportSize().width);
+        Assertions.assertEquals(200, page.viewportSize().height);
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/playwright/PlaywrightAdapter.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/PlaywrightAdapter.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.playwright;
+
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Playwright;
+
+/**
+ * Interface for adapting Playwright browser launch and context options. This allows for a more extensive configuration
+ * of Playwright's behavior in Quarkus tests, enabling users to customize how browsers are launched and how contexts are
+ * created.
+ */
+public interface PlaywrightAdapter {
+
+    /**
+     * Adapts the options for creating the Playwright instance. This method can be overridden to modify the default creation
+     * options
+     * used when initializing a Playwright instance. For example, you can set the path to the Playwright executable,
+     * configure environment variables, or adjust other settings related to Playwright's initialization.
+     *
+     * @param createOptions The create options to be adapted before creating a Playwright browser instance.
+     */
+    default Playwright.CreateOptions adaptCreateOptions(Playwright.CreateOptions createOptions) {
+        return createOptions;
+    };
+
+    /**
+     * Adapts the launch options for the Playwright browser. This method can be overridden to modify the default launch options
+     * used when starting a browser instance. For example, you can set headless mode, specify a user agent, or configure other
+     * launch parameters.
+     *
+     * @param launchOptions The launch options to be adapted before launching the browser.
+     */
+    default BrowserType.LaunchOptions adaptLaunchOptions(BrowserType.LaunchOptions launchOptions) {
+        return launchOptions;
+    };
+
+    /**
+     * Adapts the options for creating a new browser context. This method can be overridden to modify the default context
+     * options
+     * used when creating a new browser context. For example, you can set viewport size, user agent, or configure other context
+     * parameters.
+     *
+     * @param newContextOptions The new context options to be adapted before creating a browser context.
+     */
+    default Browser.NewContextOptions adaptNewContextOptions(Browser.NewContextOptions newContextOptions) {
+        return newContextOptions;
+    };
+
+}

--- a/runtime/src/main/java/io/quarkiverse/playwright/QuarkusPlaywrightManager.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/QuarkusPlaywrightManager.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.playwright;
 
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
@@ -44,6 +45,10 @@ import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
  * @since 1.0
  */
 public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurableLifecycleManager<WithPlaywright> {
+
+    public static class NoOpAdapter implements PlaywrightAdapter {
+        // No-op implementation, can be used as a default adapter
+    }
 
     /**
      * Holds the configuration options from the {@link WithPlaywright} annotation.
@@ -110,8 +115,17 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
             env.put("PWDEBUG", "1");
         }
 
+        PlaywrightAdapter adapter;
+        try {
+            adapter = this.options.playwrightAdapter().getDeclaredConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new IllegalStateException("Adapter class cannot be created", e);
+        }
+
         // Create Playwright instance with the specified environment variables
-        this.playwright = Playwright.create(new Playwright.CreateOptions().setEnv(env));
+        this.playwright = Playwright.create(
+                adapter.adaptCreateOptions(
+                        new Playwright.CreateOptions().setEnv(env)));
 
         // register testId attribute default to "data-testid"
         this.playwright.selectors().setTestIdAttribute(this.options.testId());
@@ -122,13 +136,14 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
         }
 
         // Configure launch options based on @WithPlaywright attributes
-        final LaunchOptions launchOptions = new LaunchOptions()
-                .setChannel(this.options.channel())
-                .setChromiumSandbox(this.options.chromiumSandbox())
-                .setHeadless(this.options.headless())
-                .setSlowMo(this.options.slowMo())
-                .setEnv(env)
-                .setArgs(Arrays.asList(this.options.args()));
+        final LaunchOptions launchOptions = adapter.adaptLaunchOptions(
+                new LaunchOptions()
+                        .setChannel(this.options.channel())
+                        .setChromiumSandbox(this.options.chromiumSandbox())
+                        .setHeadless(this.options.headless())
+                        .setSlowMo(this.options.slowMo())
+                        .setEnv(env)
+                        .setArgs(Arrays.asList(this.options.args())));
 
         // Launch the browser based on the specified type (CHROMIUM, FIREFOX, or WEBKIT)
         this.playwrightBrowser = browser(playwright, this.options.browser()).launch(launchOptions);
@@ -141,7 +156,7 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
 
         applyBrowserContextConfig(contextOptions, this.options.browserContext());
 
-        this.playwrightContext = playwrightBrowser.newContext(contextOptions);
+        this.playwrightContext = playwrightBrowser.newContext(adapter.adaptNewContextOptions(contextOptions));
 
         applyConfig();
 

--- a/runtime/src/main/java/io/quarkiverse/playwright/WithPlaywright.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/WithPlaywright.java
@@ -150,4 +150,9 @@ public @interface WithPlaywright {
      * Configuration for creation of the {@link com.microsoft.playwright.BrowserContext BrowserContext}
      */
     BrowserContextConfig browserContext() default @BrowserContextConfig;
+
+    /**
+     * Specifies a custom {@link PlaywrightAdapter} implementation to adapt the Playwright BrowserContext for testing.
+     */
+    Class<? extends PlaywrightAdapter> playwrightAdapter() default QuarkusPlaywrightManager.NoOpAdapter.class;
 }


### PR DESCRIPTION
Added the option to use custom logic to adapt the main objects created by the extension (Playwright instance, Browser, BrowserContext), so we have a more flexible mechanism to alter the configuration in case new features are added to playwright.

(Note: lemme know what you think first, I'll write the docs once we're ok on the implementation),