### PR TITLE
Add multi-browser screenshot endpoint and integration test

### DIFF
--- a/integration-tests/src/main/java/io/quarkiverse/playwright/it/PlaywrightResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/playwright/it/PlaywrightResource.java
@@ -104,4 +104,38 @@ public class PlaywrightResource {
         }
         return ariaSnapshot;
     }
+
+    /**
+     * Endpoint to take a screenshot using multiple browser types
+     */
+    @GET
+    @Path("/screenshot")
+    public String multiBrowserScreenshot() {
+        final Map<String, String> env = new HashMap<>(System.getenv());
+        env.put("DEBUG", "pw:api");
+        final BrowserType.LaunchOptions launchOptions = new BrowserType.LaunchOptions()
+                .setHeadless(true)
+                .setChromiumSandbox(false)
+                .setChannel("")
+                .setArgs(List.of("--disable-gpu"));
+
+        try (Playwright playwright = Playwright.create(new Playwright.CreateOptions().setEnv(env))) {
+            List<BrowserType> browserTypes = List.of(
+                    playwright.chromium(),
+                    playwright.webkit(),
+                    playwright.firefox());
+
+            for (BrowserType browserType : browserTypes) {
+                try (Browser browser = browserType.launch(launchOptions)) {
+                    final com.microsoft.playwright.BrowserContext context = browser.newContext();
+                    final Page page = context.newPage();
+                    page.navigate("https://playwright.dev/");
+                    java.nio.file.Path screenshotPath = java.nio.file.Paths
+                            .get("target/screenshot-" + browserType.name() + ".png");
+                    page.screenshot(new Page.ScreenshotOptions().setPath(screenshotPath));
+                }
+            }
+        }
+        return "Screenshots taken";
+    }
 }

--- a/integration-tests/src/main/java/io/quarkiverse/playwright/it/PlaywrightResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/playwright/it/PlaywrightResource.java
@@ -116,8 +116,7 @@ public class PlaywrightResource {
         final BrowserType.LaunchOptions launchOptions = new BrowserType.LaunchOptions()
                 .setHeadless(true)
                 .setChromiumSandbox(false)
-                .setChannel("")
-                .setArgs(List.of("--disable-gpu"));
+                .setChannel("");
 
         try (Playwright playwright = Playwright.create(new Playwright.CreateOptions().setEnv(env))) {
             List<BrowserType> browserTypes = List.of(

--- a/integration-tests/src/test/java/io/quarkiverse/playwright/it/PlaywrightResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/playwright/it/PlaywrightResourceTest.java
@@ -2,6 +2,11 @@ package io.quarkiverse.playwright.it;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,5 +32,21 @@ public class PlaywrightResourceTest {
                 .statusCode(200)
                 // If Aria did snapshot in AI Mode then the iframe contents will be included
                 .body(containsString("OpenStreetMap contributors"));
+    }
+
+    @Test
+    public void testMultiBrowserScreenshotEndpoint() throws Exception {
+        given()
+                .when().get("/playwright/screenshot")
+                .then()
+                .statusCode(200)
+                .body(is("Screenshots taken"));
+
+        String[] browsers = { "chromium", "webkit", "firefox" };
+        for (String browser : browsers) {
+            Path screenshotPath = Paths.get("target/screenshot-" + browser + ".png");
+            assertTrue(Files.exists(screenshotPath), "Screenshot file should exist for " + browser);
+            assertTrue(Files.size(screenshotPath) > 0, "Screenshot file should not be empty for " + browser);
+        }
     }
 }


### PR DESCRIPTION
I was testing taking screenshots from multiple browsers in native mode to ensure no errors, so wanted to contribute these tests.

Added
- Endpoint "/screenshot" to run through chrome, webkit and firefox and take a screenshot
- Integration test that checks the screenshots exist and are not empty files.