### PR TITLE
Add Playwright Dev Services with optional shared-network host access

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ public class WithDefaultPlaywrightTest {
 
 Use the annotation `@WithPlaywright()` to change the browser (Chromium, Firefox, Webkit), headless, enable debug, logs and other options.
 
+You can also connect to a remote Playwright browser server instead of launching a local browser:
+
+```properties
+quarkus.playwright.endpoint=ws://localhost:3000/
+```
+
+To have Quarkus start a Playwright container automatically in dev/test, enable Dev Services:
+
+```properties
+quarkus.playwright.devservices.enabled=true
+# optional, defaults to mcr.microsoft.com/playwright:v1.60.0-noble
+quarkus.playwright.devservices.image-name=mcr.microsoft.com/playwright:v1.60.0-noble
+# optional, defaults to false, enable verbose logging. Logging will be redirected to the
+# Quarkus logging as the container is stopped after execution
+quarkus.playwright.devservices.verbose=true
+```
+
+When Dev Services is enabled, `quarkus.playwright.endpoint` is derived automatically from the started container.
+
 Debug your tests with the Playwright inspector `@WithPlaywright(debug=true)`:
 
 ![Debug](https://github.com/quarkiverse/quarkus-playwright/blob/main/docs/modules/ROOT/assets/images/playwright-debug.gif)

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -20,9 +20,17 @@
             <artifactId>quarkus-core-deployment</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-devservices-deployment</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.quarkiverse.playwright</groupId>
             <artifactId>quarkus-playwright</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightBuildTimeConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightBuildTimeConfig.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.playwright.deployment;
+
+import io.quarkus.runtime.annotations.ConfigDocDefault;
+import io.quarkus.runtime.annotations.ConfigDocSection;
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+@ConfigMapping(prefix = "quarkus.playwright")
+public interface PlaywrightBuildTimeConfig {
+
+    @ConfigDocSection
+    PlaywrightDevServicesConfig devservices();
+
+    @ConfigGroup
+    interface PlaywrightDevServicesConfig {
+        String DEFAULT_IMAGE = "mcr.microsoft.com/playwright:v1.60.0-noble";
+
+        /**
+         * Starts a Playwright server container in dev and test modes.
+         */
+        @WithDefault("false")
+        boolean enabled();
+
+        /**
+         * Playwright container image.
+         */
+        @WithDefault(DEFAULT_IMAGE)
+        @ConfigDocDefault(DEFAULT_IMAGE)
+        String imageName();
+
+        /**
+         * Starts the playwright container with verbose logging
+         */
+        @WithDefault("false")
+        boolean verbose();
+
+        /**
+         * Whether to use a shared Docker network for the Playwright container, allowing it
+         * to access the host machine via {@code host.testcontainers.internal} (e.g. to reach
+         * the application under test running on the host during integration tests).
+         */
+        @WithDefault("false")
+        boolean sharedNetwork();
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightProcessor.java
@@ -1,14 +1,20 @@
 package io.quarkiverse.playwright.deployment;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.testcontainers.Testcontainers;
 
 import com.microsoft.playwright.Browser;
 import com.microsoft.playwright.ElementHandle;
@@ -27,8 +33,12 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.CuratedApplicationShutdownBuildItem;
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+import io.quarkus.deployment.builditem.DockerStatusBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.IndexDependencyBuildItem;
+import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.NativeImageEnableAllCharsetsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.NativeImageResourcePatternsBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
@@ -37,6 +47,10 @@ import io.quarkus.logging.Log;
 class PlaywrightProcessor {
 
     private static final String FEATURE = "playwright";
+    private static final String PLAYWRIGHT_ENDPOINT_CONFIG = "quarkus.playwright.endpoint";
+
+    private static volatile DevServicesResultBuildItem.RunningDevService runningDevService;
+    private static volatile PlaywrightServerContainer.PlaywrightDevServiceConfiguration capturedDevServiceConfiguration;
 
     @BuildStep
     FeatureBuildItem feature() {
@@ -206,6 +220,68 @@ class PlaywrightProcessor {
         recorder.initialize();
     }
 
+    @BuildStep(onlyIfNot = IsNormal.class)
+    DevServicesResultBuildItem startPlaywrightDevService(
+            LaunchModeBuildItem launchMode,
+            DockerStatusBuildItem dockerStatus,
+            PlaywrightBuildTimeConfig config,
+            CuratedApplicationShutdownBuildItem shutdown) {
+        if (!config.devservices().enabled()) {
+            return null;
+        }
+
+        if (StringUtils
+                .isNotBlank(ConfigProvider.getConfig().getOptionalValue(PLAYWRIGHT_ENDPOINT_CONFIG, String.class).orElse(""))) {
+            Log.debugf("Not starting Playwright Dev Services because '%s' is already configured", PLAYWRIGHT_ENDPOINT_CONFIG);
+            return null;
+        }
+
+        if (!dockerStatus.isContainerRuntimeAvailable()) {
+            Log.warn("Docker is not available, Playwright Dev Services will not start");
+            return null;
+        }
+
+        final PlaywrightServerContainer.PlaywrightDevServiceConfiguration currentConfiguration = new PlaywrightServerContainer.PlaywrightDevServiceConfiguration(
+                config.devservices().imageName(),
+                config.devservices().verbose(),
+                config.devservices().sharedNetwork());
+
+        if (runningDevService != null && Objects.equals(currentConfiguration, capturedDevServiceConfiguration)) {
+            return runningDevService.toBuildItem();
+        }
+
+        closeRunningDevService();
+
+        if (currentConfiguration.sharedNetwork()) {
+            final int httpTestPort = ConfigProvider.getConfig()
+                    .getOptionalValue("quarkus.http.test-port", Integer.class)
+                    .orElse(8081);
+            Testcontainers.exposeHostPorts(httpTestPort);
+        }
+
+        final PlaywrightServerContainer container = new PlaywrightServerContainer(currentConfiguration);
+        container.start();
+
+        final String endpoint = String.format("ws://%s:%d/", container.getHost(),
+                container.getMappedPort(PlaywrightServerContainer.PLAYWRIGHT_SERVER_PORT));
+        final Map<String, String> devServiceConfig = Map.of(PLAYWRIGHT_ENDPOINT_CONFIG, endpoint);
+
+        runningDevService = new DevServicesResultBuildItem.RunningDevService(
+                FEATURE,
+                "Playwright browser server",
+                container.getContainerId(),
+                container::stop,
+                devServiceConfig);
+        capturedDevServiceConfiguration = currentConfiguration;
+
+        if (shutdown != null) {
+            shutdown.addCloseTask(PlaywrightProcessor::closeRunningDevService, true);
+        }
+        Log.infof("Playwright Dev Services started at %s using image %s", endpoint, config.devservices().imageName());
+
+        return runningDevService.toBuildItem();
+    }
+
     @BuildStep(onlyIf = IsNormal.class)
     void registerNativeDrivers(BuildProducer<NativeImageResourcePatternsBuildItem> nativeImageResourcePatterns) {
         final NativeImageResourcePatternsBuildItem.Builder builder = NativeImageResourcePatternsBuildItem.builder();
@@ -239,4 +315,17 @@ class PlaywrightProcessor {
         Log.debugf("Implementors: %s", classes);
         return new ArrayList<>(classes);
     }
+
+    private static synchronized void closeRunningDevService() {
+        if (runningDevService != null) {
+            try {
+                runningDevService.close();
+            } catch (IOException e) {
+                Log.debug("Failed to stop Playwright Dev Services container", e);
+            }
+            runningDevService = null;
+            capturedDevServiceConfiguration = null;
+        }
+    }
+
 }

--- a/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightServerContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightServerContainer.java
@@ -1,0 +1,105 @@
+package io.quarkiverse.playwright.deployment;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import com.microsoft.playwright.Playwright;
+
+/**
+ * A Testcontainers implementation for running a Playwright server in a Docker container.
+ *
+ * This container extends GenericContainer to provide a containerized Playwright server
+ * that listens on port 3000 and can be used for browser automation testing. The npx-installed
+ * playwright CLI version is pinned to the version of the com.microsoft.playwright:playwright
+ * client library on the classpath (read from its jar manifest), since the server and client
+ * must run matching Playwright versions regardless of which Docker image is configured.
+ *
+ * The container supports configuration options including:
+ * - Custom Docker image selection
+ * - Verbose mode for debugging with Playwright API logs
+ * - Shared network configuration for container networking
+ *
+ * When verbose mode is enabled, the container will output both stdout and stderr logs
+ * to the configured logger, with stdout logged at INFO level and stderr at ERROR level.
+ * Debug output from Playwright's internal API (pw:api) is also enabled in verbose mode.
+ *
+ * The container exposes the Playwright server on port 3000 and uses a listening port
+ * wait strategy to ensure the server is ready before proceeding with tests.
+ */
+class PlaywrightServerContainer extends GenericContainer<PlaywrightServerContainer> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlaywrightServerContainer.class);
+    public static final int PLAYWRIGHT_SERVER_PORT = 3000;
+
+    record PlaywrightDevServiceConfiguration(String imageName, boolean verbose, boolean sharedNetwork) {
+    }
+
+    private final PlaywrightDevServiceConfiguration config;
+
+    PlaywrightServerContainer(PlaywrightDevServiceConfiguration config) {
+        super(DockerImageName.parse(config.imageName));
+        this.config = config;
+        if (config.verbose) {
+            withEnv("DEBUG", "pw:api");
+        }
+        if (config.sharedNetwork) {
+            withNetwork(Network.SHARED);
+        }
+        withExposedPorts(PLAYWRIGHT_SERVER_PORT);
+        withCommand("/bin/sh", "-c", playwrightServerCommand());
+        waitingFor(Wait.forListeningPort());
+    }
+
+    /**
+     * Pins the npx-installed playwright CLI/server to the exact version of the
+     * com.microsoft.playwright:playwright client library on the classpath, read from its jar
+     * manifest's Implementation-Version. The Playwright client and server must run matching
+     * versions to talk to each other. The version baked into a given Docker image tag isn't
+     * a reliable proxy for that (the tag may be missing, e.g. for a user-supplied custom image).
+     * Without an explicit version, "npx -y playwright" would resolve whatever is newest on the
+     * npm registry at container start, silently drifting away from the client and causing the
+     * "Playwright version mismatch" server/client error.
+     */
+    private static String playwrightServerCommand() {
+        final String clientVersion = Playwright.class.getPackage().getImplementationVersion();
+        final String npxPackage;
+        if (clientVersion != null) {
+            npxPackage = "playwright@" + clientVersion;
+        } else {
+            LOGGER.warn(
+                    "Could not determine the com.microsoft.playwright:playwright client library version; falling back to "
+                            + "the latest npx playwright package, which may not match the client version and cause a server/client "
+                            + "version mismatch");
+            npxPackage = "playwright";
+        }
+        return "npx -y " + npxPackage + " run-server --host 0.0.0.0 --port " + PLAYWRIGHT_SERVER_PORT;
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        if (config.verbose) {
+            followOutput(this::writeToStdOut, OutputFrame.OutputType.STDOUT);
+            followOutput(this::writeToStdErr, OutputFrame.OutputType.STDERR);
+        }
+    }
+
+    private void writeToStdOut(OutputFrame frame) {
+        writeOutputFrame(frame, Level.INFO);
+    }
+
+    private void writeToStdErr(OutputFrame frame) {
+        writeOutputFrame(frame, Level.ERROR);
+    }
+
+    private void writeOutputFrame(OutputFrame frame, Level level) {
+        LOGGER.atLevel(level).log(frame.getUtf8StringWithoutLineEnding());
+    }
+
+}

--- a/deployment/src/test/java/io/quarkiverse/playwright/deployment/PlaywrightDefaultImageVersionTest.java
+++ b/deployment/src/test/java/io/quarkiverse/playwright/deployment/PlaywrightDefaultImageVersionTest.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.playwright.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.playwright.Playwright;
+
+/**
+ * Guards against the default Playwright Dev Service image drifting out of sync with the
+ * com.microsoft.playwright:playwright client library version.
+ *
+ * The dev service container pins the npx-installed Playwright server to the client library
+ * version (see {@link PlaywrightServerContainer}), so a mismatch here isn't a functional bug.
+ * It does mean the documented default image - and the browsers baked into it - no longer match
+ * the version the extension actually exercises by default, which this test is meant to catch.
+ */
+class PlaywrightDefaultImageVersionTest {
+
+    private static final Pattern IMAGE_TAG_VERSION_PATTERN = Pattern.compile("^v?(\\d+\\.\\d+\\.\\d+)");
+
+    @Test
+    void defaultImageVersionMatchesClientLibraryVersion() {
+        final String clientVersion = Playwright.class.getPackage().getImplementationVersion();
+        assertNotNull(clientVersion,
+                "Could not read the com.microsoft.playwright:playwright client library version from its jar manifest");
+
+        final String imageName = PlaywrightBuildTimeConfig.PlaywrightDevServicesConfig.DEFAULT_IMAGE;
+        final String tag = imageName.substring(imageName.lastIndexOf(':') + 1);
+        final Matcher matcher = IMAGE_TAG_VERSION_PATTERN.matcher(tag);
+        assertNotNull(matcher.find() ? Boolean.TRUE : null,
+                "Could not determine a Playwright version from the default image tag '" + tag + "'");
+
+        assertEquals(clientVersion, matcher.group(1),
+                "The default Playwright Dev Service image (" + imageName + ") is pinned to a version that no longer "
+                        + "matches the com.microsoft.playwright:playwright client library version (" + clientVersion + "). "
+                        + "When upgrading the playright.version property in pom.xml, also update "
+                        + "PlaywrightBuildTimeConfig.PlaywrightDevServicesConfig.DEFAULT_IMAGE to the matching "
+                        + "mcr.microsoft.com/playwright image tag.");
+    }
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -145,6 +145,80 @@ public class WithAdapterPlaywrightTest {
 }
 ----
 
+=== Dev Services
+
+Instead of launching a local browser process for each test, you can connect to a remote Playwright browser server:
+
+[source,properties]
+----
+quarkus.playwright.endpoint=ws://localhost:3000/
+----
+
+To have Quarkus start a Playwright server container automatically in dev and test mode, enable Dev Services:
+
+[source,properties]
+----
+quarkus.playwright.devservices.enabled=true
+# optional, defaults to mcr.microsoft.com/playwright:v1.60.0-noble
+quarkus.playwright.devservices.image-name=mcr.microsoft.com/playwright:v1.60.0-noble
+# optional, defaults to false, enable verbose logging. Logging will be redirected to the
+# Quarkus logging as the container is stopped after execution
+quarkus.playwright.devservices.verbose=true
+----
+
+When Dev Services is enabled, `quarkus.playwright.endpoint` is derived automatically from the started container.
+
+=== Connecting to the Host Machine (Dev Services)
+
+By default, the Playwright server started by Dev Services runs in its own Docker container, isolated from the host
+machine. This is fine when your application under test is also running in a container on the same Docker network.
+However, it is common during development and in CI to run the Quarkus application directly on the host (e.g. via
+`@QuarkusTest`'s in-process HTTP server) while Playwright runs in a container, navigating to that host application
+over the network.
+
+Docker provides `host.docker.internal` for this purpose, but it is only available on Docker Desktop (macOS/Windows)
+and not on Linux, where most CI runners execute. To provide a portable solution, Testcontainers offers
+`host.testcontainers.internal`, a DNS alias that resolves to the host machine from within a container, regardless of
+the operating system.
+
+To enable this for the Playwright Dev Service, set:
+
+[source,properties]
+----
+quarkus.playwright.devservices.shared-network=true
+----
+
+When enabled:
+
+* The Playwright container is attached to a shared Testcontainers Docker network.
+* The host's `quarkus.http.test-port` (defaults to `8081`) is exposed to that network via
+  `host.testcontainers.internal`.
+* From within your test, you can navigate Playwright to the application under test using
+  `http://host.testcontainers.internal:<quarkus.http.test-port>/`.
+
+[source, java]
+----
+@QuarkusTest
+@WithPlaywright
+public class HostConnectionTest {
+
+    @InjectPlaywright
+    BrowserContext context;
+
+    @Test
+    public void testIndex() {
+        final Page page = context.newPage();
+        Response response = page.navigate("http://host.testcontainers.internal:8081/");
+        Assertions.assertEquals("OK", response.statusText());
+    }
+}
+----
+
+NOTE: `quarkus.playwright.devservices.shared-network` defaults to `false`. Enabling shared networking starts an
+additional ambassador container and Docker network for every Dev Services run, and places the Playwright container
+on a named network rather than the default bridge network. Only enable it when your test actually needs to reach
+the host machine.
+
 == Runtime Usage
 
 Leverage Playwright for screen scraping or other browser tasks in your runtime application, including support for GraalVM native compilation.

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+%remote.quarkus.playwright.devservices.enabled=true
+%remote.quarkus.playwright.devservices.verbose=true
+%remote.quarkus.playwright.devservices.shared-network=true

--- a/integration-tests/src/main/resources/templates/pub/index.html
+++ b/integration-tests/src/main/resources/templates/pub/index.html
@@ -10,7 +10,7 @@
         <div class="toast-header">
             <i class="bi bi-lightning-fill"></i>
             <strong class="me-auto toast-title"></strong>
-            <small>/hello</small>
+            <small data-testid="greeting">/hello</small>
         </div>
         <div class="toast-body">
         </div>

--- a/integration-tests/src/test/java/io/quarkiverse/playwright/it/PlaywrightAppTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/playwright/it/PlaywrightAppTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.playwright.it;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.junit.jupiter.api.Test;
+
+import com.microsoft.playwright.BrowserContext;
+
+import io.quarkiverse.playwright.InjectPlaywright;
+import io.quarkiverse.playwright.WithPlaywright;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@WithPlaywright
+@QuarkusTest
+@TestProfile(RemoteTestProfile.class)
+public class PlaywrightAppTest {
+
+    @InjectPlaywright
+    BrowserContext context;
+
+    @ConfigProperty(name = "quarkus.http.test-port")
+    int httpPort;
+
+    @Test
+    public void test() {
+        var page = context.newPage();
+        page.navigate("http://host.testcontainers.internal:" + httpPort);
+
+        page.waitForLoadState();
+
+        assertThat(page.getByTestId("greeting")).hasText("/hello");
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/playwright/it/RemoteTestProfile.java
+++ b/integration-tests/src/test/java/io/quarkiverse/playwright/it/RemoteTestProfile.java
@@ -1,0 +1,11 @@
+package io.quarkiverse.playwright.it;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class RemoteTestProfile implements QuarkusTestProfile {
+
+    @Override
+    public String getConfigProfile() {
+        return "remote";
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/playwright/PlaywrightAdapter.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/PlaywrightAdapter.java
@@ -35,6 +35,17 @@ public interface PlaywrightAdapter {
     };
 
     /**
+     * Adapts the connect options for the Playwright browser. This method can be overridden to modify the default connect
+     * options
+     * used when connecting to a browser instance.
+     *
+     * @param connectOptions The connect options to be adapted before connecting to the browser.
+     */
+    default BrowserType.ConnectOptions adaptConnectOptions(BrowserType.ConnectOptions connectOptions) {
+        return connectOptions;
+    }
+
+    /**
      * Adapts the options for creating a new browser context. This method can be overridden to modify the default context
      * options
      * used when creating a new browser context. For example, you can set viewport size, user agent, or configure other context

--- a/runtime/src/main/java/io/quarkiverse/playwright/PlaywrightRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/PlaywrightRuntimeConfig.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.playwright;
+
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "quarkus.playwright")
+public interface PlaywrightRuntimeConfig {
+
+    /**
+     * Optional Playwright websocket endpoint. If set, Playwright connects to this endpoint instead of launching a local
+     * browser.
+     */
+    Optional<String> endpoint();
+}

--- a/runtime/src/main/java/io/quarkiverse/playwright/QuarkusPlaywrightManager.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/QuarkusPlaywrightManager.java
@@ -17,6 +17,7 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.BrowserType.LaunchOptions;
 import com.microsoft.playwright.Playwright;
 
+import io.quarkus.test.common.DevServicesContext;
 import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
 
 /**
@@ -44,7 +45,8 @@ import io.quarkus.test.common.QuarkusTestResourceConfigurableLifecycleManager;
  * @see QuarkusTestResourceConfigurableLifecycleManager
  * @since 1.0
  */
-public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurableLifecycleManager<WithPlaywright> {
+public class QuarkusPlaywrightManager
+        implements QuarkusTestResourceConfigurableLifecycleManager<WithPlaywright>, DevServicesContext.ContextAware {
 
     public static class NoOpAdapter implements PlaywrightAdapter {
         // No-op implementation, can be used as a default adapter
@@ -54,6 +56,12 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
      * Holds the configuration options from the {@link WithPlaywright} annotation.
      */
     private WithPlaywright options;
+
+    /**
+     * Provides access to properties produced by Dev Services, such as the
+     * Playwright server endpoint started by the Playwright Dev Service.
+     */
+    private DevServicesContext devServicesContext;
 
     /**
      * The global Playwright instance for managing browser creation and operations.
@@ -123,7 +131,7 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
         }
 
         // Create Playwright instance with the specified environment variables
-        this.playwright = Playwright.create(
+        this.playwright = createPlaywright(
                 adapter.adaptCreateOptions(
                         new Playwright.CreateOptions().setEnv(env)));
 
@@ -135,18 +143,7 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
             this.playwright.selectors().register(selector.name(), selector.script());
         }
 
-        // Configure launch options based on @WithPlaywright attributes
-        final LaunchOptions launchOptions = adapter.adaptLaunchOptions(
-                new LaunchOptions()
-                        .setChannel(this.options.channel())
-                        .setChromiumSandbox(this.options.chromiumSandbox())
-                        .setHeadless(this.options.headless())
-                        .setSlowMo(this.options.slowMo())
-                        .setEnv(env)
-                        .setArgs(Arrays.asList(this.options.args())));
-
-        // Launch the browser based on the specified type (CHROMIUM, FIREFOX, or WEBKIT)
-        this.playwrightBrowser = browser(playwright, this.options.browser()).launch(launchOptions);
+        this.playwrightBrowser = startBrowser(adapter, env);
 
         // Configure the context, setting the video directory if specified
         final Browser.NewContextOptions contextOptions = new Browser.NewContextOptions();
@@ -161,6 +158,45 @@ public class QuarkusPlaywrightManager implements QuarkusTestResourceConfigurable
         applyConfig();
 
         return Collections.emptyMap();
+    }
+
+    @Override
+    public void setIntegrationTestContext(DevServicesContext context) {
+        this.devServicesContext = context;
+    }
+
+    protected String resolveEndpoint() {
+        if (this.devServicesContext != null) {
+            return this.devServicesContext.devServicesProperties().getOrDefault("quarkus.playwright.endpoint", "");
+        }
+
+        return "";
+    }
+
+    protected Playwright createPlaywright(Playwright.CreateOptions createOptions) {
+        return Playwright.create(createOptions);
+    }
+
+    private Browser startBrowser(PlaywrightAdapter adapter, Map<String, String> env) {
+        final BrowserType browserType = browser(playwright, this.options.browser());
+        final String endpoint = resolveEndpoint();
+
+        if (StringUtils.isNotBlank(endpoint)) {
+            final BrowserType.ConnectOptions connectOptions = adapter.adaptConnectOptions(
+                    new BrowserType.ConnectOptions().setSlowMo(this.options.slowMo()));
+            return browserType.connect(endpoint, connectOptions);
+        }
+
+        // No endpoint configured, so launch a local browser process.
+        final LaunchOptions launchOptions = adapter.adaptLaunchOptions(
+                new LaunchOptions()
+                        .setChannel(this.options.channel())
+                        .setChromiumSandbox(this.options.chromiumSandbox())
+                        .setHeadless(this.options.headless())
+                        .setSlowMo(this.options.slowMo())
+                        .setEnv(env)
+                        .setArgs(Arrays.asList(this.options.args())));
+        return browserType.launch(launchOptions);
     }
 
     private static void applyBrowserContextConfig(NewContextOptions contextOptions, BrowserContextConfig config) {


### PR DESCRIPTION
Adds a Dev Services-managed Playwright server container that the test browser context connects to via quarkus.playwright.endpoint. When quarkus.playwright.devservices.shared-network is enabled, the container joins a shared Testcontainers network and the host's HTTP test port is exposed via host.testcontainers.internal, so tests can reach an application running on the host (e.g. via @QuarkusTest) regardless of OS.

Main reason for this was playwrights policy to lag a bit behind on new releases of OSes to support (e.g. the late Ubuntu 26 LTS support, see https://github.com/microsoft/playwright/issues/40117). By running the browser in a container, we can detach the running of the browser from the main builder OS used. 