### PR TITLE
Add support for additional container arguments

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightServerContainer.java
+++ b/deployment/src/main/java/io/quarkiverse/playwright/deployment/PlaywrightServerContainer.java
@@ -13,22 +13,22 @@ import com.microsoft.playwright.Playwright;
 
 /**
  * A Testcontainers implementation for running a Playwright server in a Docker container.
- *
+ * <p>
  * This container extends GenericContainer to provide a containerized Playwright server
  * that listens on port 3000 and can be used for browser automation testing. The npx-installed
  * playwright CLI version is pinned to the version of the com.microsoft.playwright:playwright
  * client library on the classpath (read from its jar manifest), since the server and client
  * must run matching Playwright versions regardless of which Docker image is configured.
- *
+ * <p>
  * The container supports configuration options including:
  * - Custom Docker image selection
  * - Verbose mode for debugging with Playwright API logs
  * - Shared network configuration for container networking
- *
+ * <p>
  * When verbose mode is enabled, the container will output both stdout and stderr logs
  * to the configured logger, with stdout logged at INFO level and stderr at ERROR level.
  * Debug output from Playwright's internal API (pw:api) is also enabled in verbose mode.
- *
+ * <p>
  * The container exposes the Playwright server on port 3000 and uses a listening port
  * wait strategy to ensure the server is ready before proceeding with tests.
  */
@@ -78,7 +78,7 @@ class PlaywrightServerContainer extends GenericContainer<PlaywrightServerContain
                             + "version mismatch");
             npxPackage = "playwright";
         }
-        return "npx -y " + npxPackage + " run-server --host 0.0.0.0 --port " + PLAYWRIGHT_SERVER_PORT;
+        return "npx -y " + npxPackage + " run-server --host 0.0.0.0 --port " + PLAYWRIGHT_SERVER_PORT + " --unsafe";
     }
 
     @Override

--- a/runtime/src/main/java/io/quarkiverse/playwright/QuarkusPlaywrightManager.java
+++ b/runtime/src/main/java/io/quarkiverse/playwright/QuarkusPlaywrightManager.java
@@ -3,10 +3,12 @@ package io.quarkiverse.playwright;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -183,7 +185,9 @@ public class QuarkusPlaywrightManager
 
         if (StringUtils.isNotBlank(endpoint)) {
             final BrowserType.ConnectOptions connectOptions = adapter.adaptConnectOptions(
-                    new BrowserType.ConnectOptions().setSlowMo(this.options.slowMo()));
+                    new BrowserType.ConnectOptions()
+                            .setSlowMo(this.options.slowMo())
+                            .setHeaders(remoteLaunchOptionsHeaders()));
             return browserType.connect(endpoint, connectOptions);
         }
 
@@ -197,6 +201,32 @@ public class QuarkusPlaywrightManager
                         .setEnv(env)
                         .setArgs(Arrays.asList(this.options.args())));
         return browserType.launch(launchOptions);
+    }
+
+    /**
+     * Maps the subset of {@link WithPlaywright} launch options that a remote Playwright
+     * server (Dev Service, {@code run-server --unsafe}) actually accepts into the
+     * {@code x-playwright-launch-options} connect header, mirroring what the local-launch
+     * branch above sets directly on {@link LaunchOptions}. {@code env} has no remote
+     * equivalent — the server process is already running with its own environment before a
+     * client ever connects — so it's only applied to a locally-launched browser.
+     */
+    private Map<String, String> remoteLaunchOptionsHeaders() {
+        JsonArrayBuilder argsBuilder = Json.createArrayBuilder();
+        Arrays.stream(this.options.args()).forEach(argsBuilder::add);
+
+        JsonObjectBuilder launchOptionsBuilder = Json.createObjectBuilder()
+                .add("args", argsBuilder.build())
+                .add("headless", this.options.headless())
+                .add("chromiumSandbox", this.options.chromiumSandbox());
+        if (StringUtils.isNotBlank(this.options.channel())) {
+            launchOptionsBuilder.add("channel", this.options.channel());
+        }
+        JsonObject launchOptions = launchOptionsBuilder.build();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put("x-playwright-launch-options", launchOptions.toString());
+        return headers;
     }
 
     private static void applyBrowserContextConfig(NewContextOptions contextOptions, BrowserContextConfig config) {


### PR DESCRIPTION
This patch adds support to include more of the options which can be passed into WithPlaywright to pass along to the container process running in docker, brining the local and containerized version closer together.